### PR TITLE
Disable responsive-design suite by default

### DIFF
--- a/resources/tests.mjs
+++ b/resources/tests.mjs
@@ -1117,6 +1117,7 @@ Suites.push({
     name: "Responsive-Design",
     url: "experimental/responsive-design/dist/index.html",
     tags: ["responsive-design", "webcomponents", "experimental"],
+    disabled: true,
     type: "async",
     async prepare(page) {
         (await page.waitForElement("#content-iframe")).focus();


### PR DESCRIPTION
This pull request includes a small change to the `resources/tests.mjs` file. The change disables the "Responsive-Design" test suite by adding a `disabled: true` property to its configuration.