### PR TITLE
Keep Responsive-Design content visibility wait live

### DIFF
--- a/experimental/tests.mjs
+++ b/experimental/tests.mjs
@@ -242,7 +242,12 @@ export const ExperimentalSuites = freezeSuites([
                     chatInput.enter("keydown");
                     page.layout();
                 }
-                await cvWorkComplete;
+
+                // Safari can overscroll the chat element here and never send the
+                // video grid's contentvisibilityautostatechange event. See
+                // https://github.com/WebKit/Speedometer/issues/525. Remove this
+                // fallback once Speedometer CI runs a Safari with that WebKit fix.
+                await Promise.race([cvWorkComplete, new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))]);
             }),
             new BenchmarkTestStep("IncreaseWidthIn5Steps", async (page) => {
                 const widths = [560, 640, 704, 768, 800];


### PR DESCRIPTION
Keep the Responsive-Design async step from hanging when Safari overscrolls the chat section.

Safari stable can overscroll the chat element in this workload, tracked in https://github.com/WebKit/Speedometer/issues/525. When that happens, the benchmark can wait forever for `video-grid-content-visibility-complete`, which is emitted from a `contentvisibilityautostatechange` handler.

That native event only fires when the browser changes the element's skipped state. If no skipped-state transition occurs, the benchmark has already forced layout for the preceding interactions and should wait for rendering to settle rather than blocking forever.

This keeps the content-visibility completion signal when it happens, and falls back to a double `requestAnimationFrame` for liveness.
