### PR TITLE
Clean up IndexedDB previous-page listener

### DIFF
--- a/suites-experimental/javascript-wc-indexeddb/dist/src/workload-test.mjs
+++ b/suites-experimental/javascript-wc-indexeddb/dist/src/workload-test.mjs
@@ -22,6 +22,12 @@ const deletePromise = new Promise((resolve) => {
     window.addEventListener(promisesEventsNames.delete, () => resolve());
 });
 
+function waitForPreviousPageLoaded() {
+    return new Promise((resolve) => {
+        window.addEventListener("previous-page-loaded", resolve, { once: true });
+    });
+}
+
 const suites = {
     default: new BenchmarkSuite("indexeddb", [
         new BenchmarkStep(`Adding${numberOfItemsToAdd}Items`, async () => {
@@ -65,14 +71,7 @@ const suites = {
         new BenchmarkStep("DeletingAllItems", async () => {
             const numberOfItemsPerIteration = 10;
             const numberOfIterations = 10;
-            function iterationFinishedListener() {
-                iterationFinishedListener.promiseResolve();
-            }
-            window.addEventListener("previous-page-loaded", iterationFinishedListener);
             for (let j = 0; j < numberOfIterations; j++) {
-                const iterationFinishedPromise = new Promise((resolve) => {
-                    iterationFinishedListener.promiseResolve = resolve;
-                });
                 const todoList = document.querySelector("todo-app").shadowRoot.querySelector("todo-list");
                 const items = todoList.shadowRoot.querySelectorAll("todo-item");
                 for (let i = numberOfItemsPerIteration - 1; i >= 0; i--) {
@@ -81,8 +80,9 @@ const suites = {
                 }
                 if (j < 9) {
                     const previousPageButton = document.querySelector("todo-app").shadowRoot.querySelector("todo-bottombar").shadowRoot.querySelector(".previous-page-button");
+                    const previousPageLoadedPromise = waitForPreviousPageLoaded();
                     previousPageButton.click();
-                    await iterationFinishedPromise;
+                    await previousPageLoadedPromise;
                 }
             }
         }),

--- a/suites-experimental/javascript-wc-indexeddb/src/workload-test.mjs
+++ b/suites-experimental/javascript-wc-indexeddb/src/workload-test.mjs
@@ -22,6 +22,12 @@ const deletePromise = new Promise((resolve) => {
     window.addEventListener(promisesEventsNames.delete, () => resolve());
 });
 
+function waitForPreviousPageLoaded() {
+    return new Promise((resolve) => {
+        window.addEventListener("previous-page-loaded", resolve, { once: true });
+    });
+}
+
 const suites = {
     default: new BenchmarkSuite("indexeddb", [
         new BenchmarkStep(`Adding${numberOfItemsToAdd}Items`, async () => {
@@ -65,14 +71,7 @@ const suites = {
         new BenchmarkStep("DeletingAllItems", async () => {
             const numberOfItemsPerIteration = 10;
             const numberOfIterations = 10;
-            function iterationFinishedListener() {
-                iterationFinishedListener.promiseResolve();
-            }
-            window.addEventListener("previous-page-loaded", iterationFinishedListener);
             for (let j = 0; j < numberOfIterations; j++) {
-                const iterationFinishedPromise = new Promise((resolve) => {
-                    iterationFinishedListener.promiseResolve = resolve;
-                });
                 const todoList = document.querySelector("todo-app").shadowRoot.querySelector("todo-list");
                 const items = todoList.shadowRoot.querySelectorAll("todo-item");
                 for (let i = numberOfItemsPerIteration - 1; i >= 0; i--) {
@@ -81,8 +80,9 @@ const suites = {
                 }
                 if (j < 9) {
                     const previousPageButton = document.querySelector("todo-app").shadowRoot.querySelector("todo-bottombar").shadowRoot.querySelector(".previous-page-button");
+                    const previousPageLoadedPromise = waitForPreviousPageLoaded();
                     previousPageButton.click();
-                    await iterationFinishedPromise;
+                    await previousPageLoadedPromise;
                 }
             }
         }),


### PR DESCRIPTION
## Summary

Rework how the `DeletingAllItems` step waits for the IndexedDB TodoMVC app to finish a
previous-page navigation.

## Problem

The step kept its promise resolver as a property hung off the `iterationFinishedListener`
function object, and registered a `previous-page-loaded` listener that was never removed:

- The resolver was shared mutable state on a function, so which promise a given event
  resolved depended on loop ordering rather than being explicit.
- The listener outlived the step, since nothing ever called `removeEventListener`.
- A promise was allocated on every one of the 10 iterations, even though the last iteration
  never navigates and never awaits it.

## Change

Add a module-scope `waitForPreviousPageLoaded()` helper that returns a promise backed by a
`{ once: true }` listener, and call it immediately before clicking the Previous button.
Each page transition now owns its own listener and resolver, and the listener removes itself
once the event fires.

`previous-page-loaded` is dispatched only from `todo-app`'s `moveToPreviousPage()`, which
runs only in response to the bottombar's `previous-page` event from that button click. So
registering the listener just before the click cannot miss the event or observe a stray one.

This is a refactor of the benchmark's synchronization only. The measured work is unchanged.

## Notes

`dist/src/workload-test.mjs` is regenerated from `src/workload-test.mjs` by
`npm run build` in `suites-experimental/javascript-wc-indexeddb`; both are updated here so
the checked-in build stays in sync.

## Validation

- `npm run test:node` — 66 passing, including the `resources.txt` validity check
- `eslint` and `prettier --check` clean on the changed source