### PR TITLE
Document IndexedDB delete/read sync boundary

### DIFF
--- a/experimental/javascript-wc-indexeddb/dist/src/workload-test.mjs
+++ b/experimental/javascript-wc-indexeddb/dist/src/workload-test.mjs
@@ -79,7 +79,13 @@ const suites = {
                     const item = items[i].shadowRoot.querySelector(".remove-todo-button");
                     item.click();
                 }
-                if (j < 9) {
+                if (j < numberOfIterations - 1) {
+                    // moveToPreviousPage() dispatches previous-page-loaded only
+                    // after the storage read for the previous page completes.
+                    // The read fetches lower item numbers than the page just
+                    // deleted, so it does not race those pending delete writes.
+                    // FinishDeletingItemsFromDB still waits for all deletes
+                    // before the suite advances.
                     const previousPageButton = document.querySelector("todo-app").shadowRoot.querySelector("todo-bottombar").shadowRoot.querySelector(".previous-page-button");
                     previousPageButton.click();
                     await iterationFinishedPromise;

--- a/experimental/javascript-wc-indexeddb/src/workload-test.mjs
+++ b/experimental/javascript-wc-indexeddb/src/workload-test.mjs
@@ -79,7 +79,13 @@ const suites = {
                     const item = items[i].shadowRoot.querySelector(".remove-todo-button");
                     item.click();
                 }
-                if (j < 9) {
+                if (j < numberOfIterations - 1) {
+                    // moveToPreviousPage() dispatches previous-page-loaded only
+                    // after the storage read for the previous page completes.
+                    // The read fetches lower item numbers than the page just
+                    // deleted, so it does not race those pending delete writes.
+                    // FinishDeletingItemsFromDB still waits for all deletes
+                    // before the suite advances.
                     const previousPageButton = document.querySelector("todo-app").shadowRoot.querySelector("todo-bottombar").shadowRoot.querySelector(".previous-page-button");
                     previousPageButton.click();
                     await iterationFinishedPromise;


### PR DESCRIPTION
Follow-up for local issue 53.

This documents the delete/read synchronization boundary in the IndexedDB workload and removes the hard-coded `9` page-transition check.

Research summary:
- `TodoApp.moveToPreviousPage()` awaits `todo-list.moveToPreviousPage()` before dispatching `previous-page-loaded`.
- `todo-list.moveToPreviousPage()` awaits `storageManager.getTodos(...)`, so `previous-page-loaded` means the previous page read has completed.
- Each previous-page read fetches lower item numbers than the page just deleted, so it does not race the pending delete writes for the just-deleted page.
- `FinishDeletingItemsFromDB` still waits for all delete transactions before the suite advances.

Validation:
- `git diff --check`

Note: local Node/npm tooling was not available in this shell, so browser CI should cover the end-to-end validation.
