### PR TITLE
Address PR #579 review comments

### DIFF
--- a/resources/benchmark-runner.mjs
+++ b/resources/benchmark-runner.mjs
@@ -163,14 +163,14 @@ class PageElement {
         this.#node.scrollIntoView(options);
     }
 
-    observeResizeEvents() {
+    async observeResizeEvents() {
         const contentWindow = this.#node.ownerDocument.defaultView;
         const state = {
             count: 0,
             lastWidth: null,
         };
         let markReady;
-        // Resolves on the first delivery so callers can seed a baseline before resizing.
+        // Resolves on the first callback so the initial width can be used as a baseline.
         const ready = new Promise((resolve) => {
             markReady = resolve;
         });
@@ -179,7 +179,7 @@ class PageElement {
                 const contentBoxSize = entry.contentBoxSize;
                 const inlineSize = Array.isArray(contentBoxSize) ? contentBoxSize[0]?.inlineSize : contentBoxSize?.inlineSize;
                 const width = inlineSize ?? entry.contentRect.width;
-                // The first delivery seeds the baseline width without counting it as a change.
+                // The first callback seeds the baseline width without counting it as a change.
                 if (state.lastWidth === null) {
                     state.lastWidth = width;
                     markReady();
@@ -192,13 +192,11 @@ class PageElement {
             }
         });
         observer.observe(this.#node);
+        await ready;
         return {
-            ready,
-            get count() {
-                return state.count;
-            },
-            disconnect() {
+            stop() {
                 observer.disconnect();
+                return state.count;
             },
         };
     }

--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -3,6 +3,14 @@ import { getTodoText } from "../resources/shared/translations.mjs";
 import { getNumberOfItemsToAdd } from "../resources/shared/todomvc-utils.mjs";
 import { freezeSuites } from "../resources/suites-helper.mjs";
 
+function reportRecipeCarouselResizeEvents(stepName, resizeEvents) {
+    const count = resizeEvents.stop();
+    if (count)
+        console.warn(`${stepName}: recipe-carousel ResizeObserver reported ${count} width change(s).`);
+    else
+        console.warn(`${stepName}: recipe-carousel ResizeObserver reported 0 width changes; expected width changes during iframe resize.`);
+}
+
 export const ExperimentalSuites = freezeSuites([
     {
         name: "TodoMVC-LocalStorage",
@@ -214,9 +222,7 @@ export const ExperimentalSuites = freezeSuites([
             new BenchmarkTestStep("ReduceWidthIn5Steps", async (page) => {
                 const widths = [768, 704, 640, 560, 480];
                 const MATCH_MEDIA_QUERY_BREAKPOINT = 640;
-                const carouselResizeObservations = page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
-                // Seed the baseline width before the synchronous width changes below.
-                await carouselResizeObservations.ready;
+                const carouselResizeEvents = await page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
 
                 // The matchMedia query is "(max-width: 640px)"
                 // Starting from a width > 640px, we'll only get 1 event when crossing to <= 640px
@@ -233,12 +239,7 @@ export const ExperimentalSuites = freezeSuites([
                 }
 
                 await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-                const { count } = carouselResizeObservations;
-                carouselResizeObservations.disconnect();
-                if (count)
-                    console.warn(`ReduceWidthIn5Steps: recipe-carousel ResizeObserver delivered ${count} coalesced width change(s).`);
-                else
-                    console.warn("ReduceWidthIn5Steps: recipe-carousel ResizeObserver delivered 0 width changes; expected width changes during iframe resize.");
+                reportRecipeCarouselResizeEvents("ReduceWidthIn5Steps", carouselResizeEvents);
             }),
             new BenchmarkTestStep("ScrollToChatAndSendMessages", async (page) => {
                 const cvWorkComplete = new Promise((resolve) => {
@@ -282,9 +283,7 @@ export const ExperimentalSuites = freezeSuites([
             new BenchmarkTestStep("IncreaseWidthIn5Steps", async (page) => {
                 const widths = [560, 640, 704, 768, 800];
                 const MATCH_MEDIA_QUERY_BREAKPOINT = 704;
-                const carouselResizeObservations = page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
-                // Seed the baseline width before the synchronous width changes below.
-                await carouselResizeObservations.ready;
+                const carouselResizeEvents = await page.querySelector(".carousel", ["cooking-app", "main-content", "recipe-carousel"]).observeResizeEvents();
 
                 // The matchMedia query is "(max-width: 640px)"
                 // Starting from a width <= 640px, we'll get 1 event when crossing back to > 640px.
@@ -301,12 +300,7 @@ export const ExperimentalSuites = freezeSuites([
                 }
 
                 await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-                const { count } = carouselResizeObservations;
-                carouselResizeObservations.disconnect();
-                if (count)
-                    console.warn(`IncreaseWidthIn5Steps: recipe-carousel ResizeObserver delivered ${count} coalesced width change(s).`);
-                else
-                    console.warn("IncreaseWidthIn5Steps: recipe-carousel ResizeObserver delivered 0 width changes; expected width changes during iframe resize.");
+                reportRecipeCarouselResizeEvents("IncreaseWidthIn5Steps", carouselResizeEvents);
             }),
         ],
     },

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -342,12 +342,15 @@ describe("PageElement", () => {
         // A fake ResizeObserver drives deliveries synchronously for exact-count assertions.
         async function createTracker() {
             let deliver;
+            const disconnect = sinon.stub();
             class FakeResizeObserver {
                 constructor(callback) {
                     deliver = (...widths) => callback(widths.map((width) => ({ contentBoxSize: [{ inlineSize: width }] })));
                 }
                 observe() {}
-                disconnect() {}
+                disconnect() {
+                    disconnect();
+                }
             }
             return withPageElement(
                 (frame) => {
@@ -358,35 +361,39 @@ describe("PageElement", () => {
                     return node;
                 },
                 (element) => ({
-                    resizeEvents: element.observeResizeEvents(),
+                    resizeEventsPromise: element.observeResizeEvents(),
                     deliver: (...widths) => deliver(...widths),
+                    disconnect,
                 })
             );
         }
 
         it("treats the first delivery as the baseline without counting it", async () => {
-            const { resizeEvents, deliver } = await createTracker();
+            const { resizeEventsPromise, deliver, disconnect } = await createTracker();
             deliver(200);
-            await resizeEvents.ready;
-            expect(resizeEvents.count).to.equal(0);
+            const resizeEvents = await resizeEventsPromise;
+            expect(resizeEvents.stop()).to.equal(0);
+            sinon.assert.calledOnce(disconnect);
         });
 
         it("counts each distinct width change exactly once", async () => {
-            const { resizeEvents, deliver } = await createTracker();
+            const { resizeEventsPromise, deliver } = await createTracker();
             deliver(200); // seed
+            const resizeEvents = await resizeEventsPromise;
             deliver(300);
             deliver(400);
             deliver(500);
-            expect(resizeEvents.count).to.equal(3);
+            expect(resizeEvents.stop()).to.equal(3);
         });
 
         it("does not count deliveries that report the same width", async () => {
-            const { resizeEvents, deliver } = await createTracker();
+            const { resizeEventsPromise, deliver } = await createTracker();
             deliver(200); // seed
+            const resizeEvents = await resizeEventsPromise;
             deliver(300);
             deliver(300);
             deliver(300);
-            expect(resizeEvents.count).to.equal(1);
+            expect(resizeEvents.stop()).to.equal(1);
         });
     });
 });


### PR DESCRIPTION
## Summary

- await the initial resize callback inside `observeResizeEvents()`
- replace separate count and disconnect access with `stop()`
- centralize recipe carousel resize reporting
- update tests for the simplified observer lifecycle

## Validation

- `npm run test:chrome`
- `npx eslint resources/benchmark-runner.mjs suites-experimental/suites.mjs tests/unittests/benchmark-runner.mjs`
- Crossbench A/B on `Responsive-Design`, 10 repetitions with 10 iterations each and zero failed runs

| Browser | Baseline | Review fix | Time delta | Bootstrap 95% interval |
| --- | ---: | ---: | ---: | ---: |
| Chrome for Testing 152 | 131.519 ms | 131.306 ms | 0.16% faster | 0.40% faster to 0.09% slower |
| Edge 151 | 112.265 ms | 109.207 ms | 2.72% faster | 6.05% faster to 0.83% slower |
| Safari 26.6 | 175.956 ms | 176.352 ms | 0.23% slower | 0.25% faster to 0.69% slower |

All intervals include zero, so no browser shows a measurable performance regression.
