### PR TITLE
Use callback terminology in resize observer tests

### DIFF
--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -3,10 +3,14 @@ import { getTodoText } from "../resources/shared/translations.mjs";
 import { getNumberOfItemsToAdd } from "../resources/shared/todomvc-utils.mjs";
 import { freezeSuites } from "../resources/suites-helper.mjs";
 
+function waitForResizeObserverCallbacks() {
+    return new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+}
+
 function reportRecipeCarouselResizeEvents(stepName, resizeEvents) {
     const count = resizeEvents.stop();
     if (count)
-        console.warn(`${stepName}: recipe-carousel ResizeObserver reported ${count} width change(s).`);
+        console.log(`${stepName}: recipe-carousel ResizeObserver reported ${count} width change(s).`);
     else
         console.warn(`${stepName}: recipe-carousel ResizeObserver reported 0 width changes; expected width changes during iframe resize.`);
 }
@@ -238,7 +242,7 @@ export const ExperimentalSuites = freezeSuites([
                         await resizeWorkPromise;
                 }
 
-                await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+                await waitForResizeObserverCallbacks();
                 reportRecipeCarouselResizeEvents("ReduceWidthIn5Steps", carouselResizeEvents);
             }),
             new BenchmarkTestStep("ScrollToChatAndSendMessages", async (page) => {
@@ -299,7 +303,7 @@ export const ExperimentalSuites = freezeSuites([
                         await resizeWorkPromise;
                 }
 
-                await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+                await waitForResizeObserverCallbacks();
                 reportRecipeCarouselResizeEvents("IncreaseWidthIn5Steps", carouselResizeEvents);
             }),
         ],

--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -6,7 +6,7 @@ import { freezeSuites } from "../resources/suites-helper.mjs";
 function reportRecipeCarouselResizeEvents(stepName, resizeEvents) {
     const count = resizeEvents.stop();
     if (count)
-        console.log(`${stepName}: recipe-carousel ResizeObserver reported ${count} width change(s).`);
+        console.warn(`${stepName}: recipe-carousel ResizeObserver reported ${count} width change(s).`);
     else
         console.warn(`${stepName}: recipe-carousel ResizeObserver reported 0 width changes; expected width changes during iframe resize.`);
 }

--- a/suites-experimental/suites.mjs
+++ b/suites-experimental/suites.mjs
@@ -3,10 +3,6 @@ import { getTodoText } from "../resources/shared/translations.mjs";
 import { getNumberOfItemsToAdd } from "../resources/shared/todomvc-utils.mjs";
 import { freezeSuites } from "../resources/suites-helper.mjs";
 
-function waitForResizeObserverCallbacks() {
-    return new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
-}
-
 function reportRecipeCarouselResizeEvents(stepName, resizeEvents) {
     const count = resizeEvents.stop();
     if (count)
@@ -242,7 +238,7 @@ export const ExperimentalSuites = freezeSuites([
                         await resizeWorkPromise;
                 }
 
-                await waitForResizeObserverCallbacks();
+                await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
                 reportRecipeCarouselResizeEvents("ReduceWidthIn5Steps", carouselResizeEvents);
             }),
             new BenchmarkTestStep("ScrollToChatAndSendMessages", async (page) => {
@@ -303,7 +299,7 @@ export const ExperimentalSuites = freezeSuites([
                         await resizeWorkPromise;
                 }
 
-                await waitForResizeObserverCallbacks();
+                await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
                 reportRecipeCarouselResizeEvents("IncreaseWidthIn5Steps", carouselResizeEvents);
             }),
         ],

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -339,7 +339,23 @@ describe("PageElement", () => {
             return result;
         }
 
-        // A fake ResizeObserver drives deliveries synchronously for exact-count assertions.
+        it("resolves after the browser's initial callback", async () => {
+            const count = await withPageElement(
+                (frame) => {
+                    const node = frame.contentDocument.createElement("div");
+                    node.id = "resize-target";
+                    frame.contentDocument.body.appendChild(node);
+                    return node;
+                },
+                async (element) => {
+                    const resizeEvents = await element.observeResizeEvents();
+                    return resizeEvents.stop();
+                }
+            );
+            expect(count).to.equal(0);
+        });
+
+        // A fake ResizeObserver drives callbacks synchronously for exact-count assertions.
         async function createTracker() {
             let deliver;
             const disconnect = sinon.stub();
@@ -368,7 +384,7 @@ describe("PageElement", () => {
             );
         }
 
-        it("treats the first delivery as the baseline without counting it", async () => {
+        it("treats the first callback as the baseline without counting it", async () => {
             const { resizeEventsPromise, deliver, disconnect } = await createTracker();
             deliver(200);
             const resizeEvents = await resizeEventsPromise;
@@ -386,7 +402,7 @@ describe("PageElement", () => {
             expect(resizeEvents.stop()).to.equal(3);
         });
 
-        it("does not count deliveries that report the same width", async () => {
+        it("does not count callbacks that report the same width", async () => {
             const { resizeEventsPromise, deliver } = await createTracker();
             deliver(200); // seed
             const resizeEvents = await resizeEventsPromise;

--- a/tests/unittests/benchmark-runner.mjs
+++ b/tests/unittests/benchmark-runner.mjs
@@ -339,22 +339,6 @@ describe("PageElement", () => {
             return result;
         }
 
-        it("resolves after the browser's initial callback", async () => {
-            const count = await withPageElement(
-                (frame) => {
-                    const node = frame.contentDocument.createElement("div");
-                    node.id = "resize-target";
-                    frame.contentDocument.body.appendChild(node);
-                    return node;
-                },
-                async (element) => {
-                    const resizeEvents = await element.observeResizeEvents();
-                    return resizeEvents.stop();
-                }
-            );
-            expect(count).to.equal(0);
-        });
-
         // A fake ResizeObserver drives callbacks synchronously for exact-count assertions.
         async function createTracker() {
             let deliver;


### PR DESCRIPTION
## Summary

- replace the remaining "delivery" wording in ResizeObserver tests with "callback"

## Rationale

This keeps the tests consistent with the terminology requested during review and already used by the implementation.

## Validation

- `npx eslint tests/unittests/benchmark-runner.mjs`
